### PR TITLE
Remove API key from image response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-wunderground",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -219,22 +219,22 @@
         "supports-color": "2.0.0"
       }
     },
+    "ci-info": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
+      "integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ=",
+      "dev": true
+    },
     "cline": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/cline/-/cline-0.8.2.tgz",
       "integrity": "sha1-6RHnQaCtLiTSnm+rLPifoyLVnHY=",
       "dev": true
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
-    },
     "coffee-script": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz",
+      "integrity": "sha1-Y1XTLPGwTN/2tITl5xF4Ky8MOb4=",
       "dev": true
     },
     "colors": {
@@ -816,6 +816,12 @@
         }
       }
     },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
+    },
     "findup-sync": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
@@ -1186,6 +1192,18 @@
         "hubot": "2.19.0"
       }
     },
+    "husky": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.13.4.tgz",
+      "integrity": "sha1-SHhcUCjeNFKlHEjBLE+UshJKFAc=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "find-parent-dir": "0.3.0",
+        "is-ci": "1.0.10",
+        "normalize-path": "1.0.0"
+      }
+    },
     "iconv-lite": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
@@ -1203,6 +1221,15 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
       "integrity": "sha1-X6eM8wG4JceKvDBC2BJyMEnqI8c=",
       "dev": true
+    },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.0.0"
+      }
     },
     "isarray": {
       "version": "0.0.1",
@@ -1621,6 +1648,12 @@
           }
         }
       }
+    },
+    "normalize-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+      "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+      "dev": true
     },
     "on-finished": {
       "version": "2.1.1",

--- a/src/wunderground.coffee
+++ b/src/wunderground.coffee
@@ -93,10 +93,12 @@ send_forecast = (msg, location, data) ->
   useMetric = process.env.HUBOT_WUNDERGROUND_USE_METRIC?
   msg.send "#{report.title} in #{location}: #{if useMetric then report.fcttext_metric else report.fcttext} (#{formatted_ttl data})"
 send_radar = (msg, location, data) ->
-  msg.send "#{data.radar.image_url}.png"
+  image_url = remove_api_key(data.radar.image_url)
+  msg.send "#{image_url}.png"
 
 send_satellite = (msg, location, data) ->
-  msg.send "#{data.satellite.image_url}.png"
+  image_url = remove_api_key(data.satellite.image_url)
+  msg.send "#{image_url}.png"
 
 send_webcam = (msg, location, data) ->
   cam = msg.random data.webcams
@@ -105,6 +107,10 @@ send_webcam = (msg, location, data) ->
     msg.send "#{cam.CURRENTIMAGEURL}.png"
   else
     msg.send "No webcams near #{location}. (#{formatted_ttl data})"
+
+# Response contains API key, which we don't want users to see
+remove_api_key = (url) ->
+  url.replace("api_key=#{process.env.HUBOT_WUNDERGROUND_API_KEY}", '_render=image')
 
 # quick normalization to reduce caching of redundant data
 key_for = (service, query) ->

--- a/test/wunderground-test.coffee
+++ b/test/wunderground-test.coffee
@@ -91,7 +91,7 @@ describe 'wunderground', ->
       try
         expect(selfRoom.messages).to.eql [
           ['alice', '@hubot radar in nashville tn']
-          ['hubot',  'http://resize.wunderground.com/cgi-bin/resize_convert?ox=gif&url=radblast/cgi-bin/radar/WUNIDS_composite%3Fcenterlat=36.16999817%26centerlon=-86.77999878%26radius=75%26newmaps=1%26smooth=1%26reproj.automerc=1%26api_key=foobarbaz123456.png']
+          ['hubot',  'http://resize.wunderground.com/cgi-bin/resize_convert?ox=gif&url=radblast/cgi-bin/radar/WUNIDS_composite%3Fcenterlat=36.16999817%26centerlon=-86.77999878%26radius=75%26newmaps=1%26smooth=1%26reproj.automerc=1%26_render=image.png']
         ]
         done()
       catch err
@@ -111,7 +111,7 @@ describe 'wunderground', ->
       try
         expect(selfRoom.messages).to.eql [
           ['alice', '@hubot satellite in nashville tn']
-          ['hubot',  'http://wublast.wunderground.com/cgi-bin/WUBLAST?lat=36.16999817&lon=-86.77999878&radius=75&width=300&height=300&key=sat_ir4_thumb&gtt=0&extension=png&proj=me&num=1&delay=25&timelabel=0&basemap=1&borders=1&theme=WUBLAST_WORLD&rand=1501902218&api_key=foobarbaz123456.png']
+          ['hubot',  'http://wublast.wunderground.com/cgi-bin/WUBLAST?lat=36.16999817&lon=-86.77999878&radius=75&width=300&height=300&key=sat_ir4_thumb&gtt=0&extension=png&proj=me&num=1&delay=25&timelabel=0&basemap=1&borders=1&theme=WUBLAST_WORLD&rand=1501902218&_render=image.png']
         ]
         done()
       catch err


### PR DESCRIPTION
The Weather Underground API will return an image URL that contains the provided API key in the query string when requesting the `radar` or `satellite` endpoints. This is not necessary information (and really shouldn't be in there), so this PR removes it from the response and replaces it with a benign `_render=image`.